### PR TITLE
Improve quantum picker usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# Quant_Rand_List
+# Quant Rand List
+
+This repository contains a simple Python script that uses IBM Quantum's free
+cloud QPUs to select a random element from any list. **An IBM Quantum account
+is required** and the script will raise an error if credentials are not
+available.
+
+## `quantum_list_picker.py`
+
+Running the script will print a randomly chosen element from a predefined list
+of 64 animals and insects.  You can also import `pick_random_element` and pass
+any list you like.
+
+### Requirements
+
+- Python 3.8+
+- `qiskit==0.45.1`
+- `qiskit-ibm-provider==0.11`
+
+Install the requirements and save your IBM Quantum API token once using:
+
+```python
+from qiskit_ibm_provider import IBMProvider
+IBMProvider.save_account("<TOKEN>")
+```
+
+You can obtain a token by signing up at [IBM Quantum](https://quantum.ibm.com/).
+
+After saving the token, execute:
+
+```bash
+python quantum_list_picker.py [--backend BACKEND_NAME]
+```
+
+To pick from your own list, import the function:
+
+```python
+from quantum_list_picker import pick_random_element
+print(pick_random_element(["foo", "bar"]))
+```
+

--- a/quantum_list_picker.py
+++ b/quantum_list_picker.py
@@ -1,0 +1,73 @@
+import math
+import argparse
+from qiskit_ibm_provider import IBMProvider  # type: ignore
+from qiskit import transpile
+from qiskit.circuit import QuantumCircuit
+
+
+def pick_random_element(items, backend_name="ibm_lima"):
+    """Pick a random element from ``items`` using an IBM Quantum backend.
+
+    Args:
+        items (list): List of items to choose from.
+        backend_name (str): IBM Quantum backend name. Defaults to 'ibm_lima'.
+
+    Returns:
+        object: Randomly chosen element from items.
+    """
+    if not items:
+        raise ValueError("The list of items cannot be empty")
+
+    num_qubits = math.ceil(math.log2(len(items))) or 1
+    qc = QuantumCircuit(num_qubits, num_qubits)
+    qc.h(range(num_qubits))
+    qc.measure(range(num_qubits), range(num_qubits))
+
+    try:
+        provider = IBMProvider()
+        backend = provider.get_backend(backend_name)
+    except Exception as exc:
+        raise RuntimeError(
+            "IBM Quantum account is not configured or backend unavailable"
+        ) from exc
+
+    compiled = transpile(qc, backend)
+    job = backend.run(compiled, shots=1)
+    result = job.result()
+    bitstring = list(result.get_counts(qc).keys())[0]
+
+    index = int(bitstring, 2) % len(items)
+    return items[index]
+
+
+DEFAULT_ITEMS = [
+        "Ant", "Bear", "Cat", "Dog", "Elephant", "Frog", "Giraffe", "Horse",
+        "Iguana", "Jaguar", "Koala", "Lion", "Monkey", "Newt", "Owl",
+        "Penguin", "Quail", "Rabbit", "Snake", "Tiger", "Urchin", "Vulture",
+        "Wolf", "Xerus", "Yak", "Zebra", "Aardvark", "Butterfly", "Cheetah",
+        "Dolphin", "Eagle", "Falcon", "Goat", "Hamster", "Impala", "Jellyfish",
+        "Kangaroo", "Lemur", "Moth", "Nightingale", "Opossum", "Parrot",
+        "Quokka", "Raccoon", "Shark", "Turtle", "Uakari", "Viper", "Walrus",
+        "Xantus", "Yakutian Horse", "Zebu", "Alpaca", "Bison", "Crab",
+        "Donkey", "Emu", "Firefly", "Gazelle", "Heron", "Insect", "Jackal",
+        "Kookaburra", "Llama"
+]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Pick a random element using IBM Quantum hardware"
+    )
+    parser.add_argument(
+        "--backend",
+        default="ibm_lima",
+        help="IBM Quantum backend name (default: ibm_lima)",
+    )
+    args = parser.parse_args()
+
+    element = pick_random_element(DEFAULT_ITEMS, backend_name=args.backend)
+    print(f"Random element: {element}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add CLI argument for selecting backend
- expose default animal list in the script
- expand README with IBM Quantum setup and CLI usage
- clarify install versions and example for using a custom list

## Testing
- `python3 -m py_compile quantum_list_picker.py`


------
https://chatgpt.com/codex/tasks/task_e_6857f506b434832f9851f1ffdbd5170c